### PR TITLE
WaiMultiSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/*
 result/*
+result

--- a/default.nix
+++ b/default.nix
@@ -5,19 +5,21 @@ let
   inherit (nixpkgs) pkgs;
 
   f = { mkDerivation, base, bytestring, bytestring-conversion
-      , case-insensitive, hspec, hspec-wai, http-media, http-types, mtl
-      , servant, servant-server, stdenv, text, wai, wai-extra
+      , case-insensitive, hspec, hspec-core, hspec-wai, http-media
+      , http-types, mtl, servant, servant-server, stdenv, text, wai
+      , wai-extra
       }:
       mkDerivation {
         pname = "hspec-wai-servant";
         version = "0.1.0.0";
         src = ./.;
         libraryHaskellDepends = [
-          base bytestring bytestring-conversion case-insensitive hspec-wai
-          http-media http-types servant text wai-extra
+          base bytestring bytestring-conversion case-insensitive hspec
+          hspec-core hspec-wai http-media http-types mtl servant text wai
+          wai-extra
         ];
         testHaskellDepends = [
-          base bytestring hspec mtl servant servant-server text wai
+          base bytestring hspec hspec-wai mtl servant servant-server text wai
         ];
         homepage = "https://github.com/ramirez7/hspec-wai-servant";
         description = "servant-client generation for hspec-wai";

--- a/hspec-wai-servant.cabal
+++ b/hspec-wai-servant.cabal
@@ -17,13 +17,17 @@ cabal-version:       >=1.10
 library
   exposed-modules:
     Test.Hspec.Wai.Servant
+    Test.Hspec.Wai.WaiMultiSession
     Test.Hspec.Wai.Servant.Assertions
     Test.Hspec.Wai.Servant.Client
     Test.Hspec.Wai.Servant.Types
   ghc-options: -Wall
   build-depends:
       base >=4.9 && <4.10
+    , hspec
     , hspec-wai
+    , hspec-core
+    , wai
     , wai-extra
     , bytestring
     , bytestring-conversion
@@ -31,6 +35,7 @@ library
     , http-types
     , http-media
     , text
+    , mtl
     , servant ==0.9.*
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -44,6 +49,7 @@ test-suite spec
   build-depends:
       base >=4.9 && <4.10
     , hspec
+    , hspec-wai
     , servant ==0.9.*
     , servant-server ==0.9.*
     , bytestring

--- a/src/Test/Hspec/Wai/Servant/Assertions.hs
+++ b/src/Test/Hspec/Wai/Servant/Assertions.hs
@@ -8,28 +8,43 @@ module Test.Hspec.Wai.Servant.Assertions
   , succeed
   ) where
 
-import           Data.Functor                 (void)
-import           GHC.Stack                    (HasCallStack)
-import qualified Test.Hspec.Wai               as W
+import           Control.Monad.IO.Class         (MonadIO(..))
+import           Data.Foldable                  (for_)
+import           Data.Functor                   (void)
+import           GHC.Stack                      (HasCallStack)
+import           Test.Hspec                     (expectationFailure)
+import qualified Test.Hspec.Wai                 as W
+import qualified Test.Hspec.Wai.Matcher         as W
 
 import           Test.Hspec.Wai.Servant.Types
+import           Test.Hspec.Wai.WaiMultiSession
 
--- | Like @shouldRespondWith@ from 'Test.Hspec.Wai', but ...
--- 1) operates on @WaiSession (TestResponse a)@ instead of @(WaiSession SResponse)@
--- 2) returns the response for later use
-shouldRespondWith :: HasCallStack => W.WaiSession (TestResponse a) -> W.ResponseMatcher -> W.WaiSession (TestResponse a)
-shouldRespondWith action matcher = do
-  tresp@(TestResponse _ sresp) <- action
-  pure sresp `W.shouldRespondWith` matcher
-  pure tresp
+class Monad m => MonadHspecWai m where
+  -- | Like @shouldRespondWith@ from 'Test.Hspec.Wai', but ...
+  -- 1) operates on @m (TestResponse a)@ instead of @(WaiSession SResponse)@
+  -- 2) returns the response for later use
+  shouldRespondWith :: HasCallStack => m (TestResponse a) -> W.ResponseMatcher -> m (TestResponse a)
+
+instance MonadHspecWai W.WaiSession where
+  shouldRespondWith action matcher = do
+    tresp@(TestResponse _ sresp) <- action
+    pure sresp `W.shouldRespondWith` matcher
+    pure tresp
+
+instance MonadHspecWai (WaiMultiSession tags) where
+  shouldRespondWith action matcher = do
+    tresp@(TestResponse _ sresp) <- action
+    for_ (W.match sresp matcher) (liftIO . expectationFailure)
+    pure tresp
+
 
 -- | Like 'shouldRespondWith', but doesn't return the response
-shouldRespondWith_ :: HasCallStack => W.WaiSession (TestResponse a) -> W.ResponseMatcher -> W.WaiExpectation
+shouldRespondWith_ :: (MonadHspecWai m, HasCallStack) => m (TestResponse a) -> W.ResponseMatcher -> m ()
 shouldRespondWith_ = (void .) . shouldRespondWith
 
 -- | Checks if the provided @action@ returns 200. If so, attempts to decode
--- the response
-succeed :: HasCallStack => W.WaiSession (TestResponse a) -> W.WaiSession a
+-- the response, throwing on failure
+succeed :: (HasCallStack, MonadIO m, MonadHspecWai m) => m (TestResponse a) -> m a
 succeed action = do
   tresp <- action `shouldRespondWith` 200
   getTestResponse tresp

--- a/src/Test/Hspec/Wai/Servant/Assertions.hs
+++ b/src/Test/Hspec/Wai/Servant/Assertions.hs
@@ -3,12 +3,12 @@
 
 -- | Assertions for use with the result of the generated client functions
 module Test.Hspec.Wai.Servant.Assertions
-  ( shouldRespondWith
+  ( MonadHspecWai (..)
   , shouldRespondWith_
   , succeed
   ) where
 
-import           Control.Monad.IO.Class         (MonadIO(..))
+import           Control.Monad.IO.Class         (MonadIO (..))
 import           Data.Foldable                  (for_)
 import           Data.Functor                   (void)
 import           GHC.Stack                      (HasCallStack)

--- a/src/Test/Hspec/Wai/Servant/Client.hs
+++ b/src/Test/Hspec/Wai/Servant/Client.hs
@@ -22,15 +22,13 @@ module Test.Hspec.Wai.Servant.Client
 import           Network.Wai.Test                (SResponse (..))
 import           Test.Hspec.Wai
 
-import           Control.Exception               (Exception, throwIO)
+import           Control.Arrow                   (left)
 import qualified Data.ByteString.Char8           as BC
 import qualified Data.ByteString.Lazy            as BL
 import qualified Data.CaseInsensitive            as CI
 import           Data.Monoid                     ((<>))
 import           Data.Proxy
-import           Data.Typeable                   (Typeable)
 import           GHC.TypeLits
-import qualified Network.HTTP.Media.MediaType    as HT
 import qualified Network.HTTP.Media.RenderHeader as HT
 import qualified Network.HTTP.Types              as HT
 import           Servant.API
@@ -55,15 +53,11 @@ performTestRequestCT ctP methodP req@TestRequest{..} =
   in TestResponse (decodeResponse ctP) <$> performTestRequest method reqWithCt
 
 -- | Will throw and fail the test if a fails to parse
-decodeResponse :: MimeUnrender ctype a => Proxy ctype -> SResponse -> WaiSession a
-decodeResponse ctProxy resp = liftIO $ either (throwIO . mkError) pure $ mimeUnrender ctProxy (simpleBody resp)
+decodeResponse :: MimeUnrender ctype a => Proxy ctype -> SResponse -> Either TestErr a
+decodeResponse ctProxy resp = left mkError $ mimeUnrender ctProxy (simpleBody resp)
   where
     ct = contentType ctProxy
     mkError err = DecodeError err ct (BL.toStrict $ simpleBody resp)
-
-data Err = DecodeError !String !HT.MediaType !BC.ByteString deriving (Show, Typeable)
-
-instance Exception Err
 
 -- | Type class to generate 'WaiSession'-based client handlers. Compare to
 -- 'HasClient' from 'Servant.Client'

--- a/src/Test/Hspec/Wai/Servant/Types.hs
+++ b/src/Test/Hspec/Wai/Servant/Types.hs
@@ -5,14 +5,17 @@
 module Test.Hspec.Wai.Servant.Types where
 
 import           Network.Wai.Test                (SResponse (..))
-import           Test.Hspec.Wai
 
+import           Control.Exception               (Exception, throwIO)
+import           Control.Monad.IO.Class          (MonadIO (..))
 import           Data.ByteString                 as B
 import           Data.ByteString.Char8           as BC
 import           Data.ByteString.Conversion.To   (toByteString')
 import           Data.ByteString.Lazy            as BL
 import           Data.Monoid                     ((<>))
 import           Data.Proxy                      (Proxy (..))
+import           Data.Typeable                   (Typeable)
+import qualified Network.HTTP.Media.MediaType    as HT
 import           Network.HTTP.Media.RenderHeader as HT
 import qualified Network.HTTP.Types              as HT
 import           Servant.API                     (MimeRender (..),
@@ -42,7 +45,11 @@ setReqBody :: (MimeRender ct a) => Proxy ct -> a -> TestRequest -> TestRequest
 setReqBody ctP a req = req { testBody = mimeRender ctP a, testHeaders = ("content-type", HT.renderHeader (contentType ctP)) : testHeaders req }
 
 -- | A raw SResponse along with a function to decode @a@
-data TestResponse a = TestResponse (SResponse -> WaiSession a) SResponse
+data TestResponse a = TestResponse (SResponse -> Either TestErr a) SResponse
 
-getTestResponse :: TestResponse a -> WaiSession a
-getTestResponse (TestResponse k sresp) = k sresp
+getTestResponse :: MonadIO m => TestResponse a -> m a
+getTestResponse (TestResponse k sresp) = either (liftIO . throwIO) pure $ k sresp
+
+data TestErr = DecodeError !String !HT.MediaType !BC.ByteString deriving (Show, Typeable)
+
+instance Exception TestErr

--- a/src/Test/Hspec/Wai/WaiMultiSession.hs
+++ b/src/Test/Hspec/Wai/WaiMultiSession.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+-- | 'WaiSession' is limited because its only a 'Reader' of a single 'Application'
+-- This is a pain if you want to test multiple 'Application's that call each other
+-- 'WaiMultiSession' is very similar to 'WaiSession', but it is a 'Reader' of
+-- multiple 'Application's, each of which is tagged at the type level with a 'Symbol'
+--
+-- This module actually has nothing to do with 'servant', but it is a pain to
+-- use multiple 'Application's without 'hspec-wai-servant's auto client generation
+-- so that's why it's in this library.
+module Test.Hspec.Wai.WaiMultiSession where
+
+import           Network.Wai             (Application)
+import           Network.Wai.Test        (runSession)
+import           Test.Hspec.Core.Spec
+import           Test.Hspec.Wai.Internal (WaiSession (..))
+
+import           Control.Monad.IO.Class  (MonadIO)
+import           Control.Monad.Reader    (ReaderT (..))
+import           Data.Proxy
+import qualified GHC.Exts                as GHCX
+import           GHC.TypeLits
+
+-- | Run a given 'WaiSession' with the 'Application' tagged with @s@ in the
+-- 'WaiMultiSession'
+--
+-- NOTE: 'ClientState' is NOT threaded through! It is just a wrapper around
+-- Cookies, so if you aren't using Cookies, you're good.
+-- FIXME: If @wai-extra@ exported 'ClientState', this would be able to be fixed.
+sendWaiSession :: forall (s :: Symbol) (tags :: [Symbol]) a
+                . (GetApplication s tags)
+               => Proxy s
+               -> Proxy tags
+               -> WaiSession a
+               -> WaiMultiSession tags a
+sendWaiSession p _ (WaiSession session) =
+  WaiMultiSession $ ReaderT $ \ma ->
+    runSession session (getApplication p ma)
+
+newtype WaiMultiSession (tags :: [Symbol]) a =
+  WaiMultiSession { unWaiMultiSession :: (ReaderT (MultiApplication tags) IO a) }
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+runWaiMultiSession :: WaiMultiSession tags a -> MultiApplication tags -> IO a
+runWaiMultiSession session app = runReaderT (unWaiMultiSession session) app
+
+type WaiMultiExpectation tags = WaiMultiSession tags ()
+
+instance Example (WaiMultiExpectation tags) where
+  type Arg (WaiMultiExpectation tags) = MultiApplication tags
+  evaluateExample e p action = evaluateExample (action $ runWaiMultiSession e) p ($ ())
+
+data MultiApplication (tags :: [Symbol]) where
+  OneApp :: Application -> MultiApplication '[s]
+  ManyApps :: Application -> MultiApplication xs -> MultiApplication (s ': xs)
+
+class GetApplication (s :: Symbol) (tags :: [Symbol]) where
+  getApplication :: Proxy s -> MultiApplication tags -> Application
+
+instance forall (s :: Symbol). GetApplication s '[s] where
+  getApplication _ (ManyApps _ _) = error "impossible"
+  getApplication _ (OneApp app)   = app
+
+instance {-# OVERLAPPABLE #-} forall (s :: Symbol) (xs :: [Symbol]). GetApplication s (s ': xs) where
+  getApplication _ (ManyApps app _) = app
+  getApplication _ (OneApp _)       = error "impossible"
+
+instance {-# OVERLAPPABLE #-} forall (s :: Symbol) (xs :: [Symbol]) (x :: Symbol)
+        . (GetApplication s xs)
+       => GetApplication s (x ': xs) where
+  getApplication p (ManyApps _ xs) = getApplication p xs
+  getApplication _ (OneApp _)      = error "impossible"
+
+instance KnownSymbol s => Show (MultiApplication '[s]) where
+  show (OneApp _)     = show $ symbolVal (Proxy :: Proxy s)
+  show (ManyApps _ _) = error "impossible"
+
+instance {-# OVERLAPPABLE #-} forall (s :: Symbol) (xs :: [Symbol])
+        . (KnownSymbol s, Show (MultiApplication xs))
+       => Show (MultiApplication (s ': xs)) where
+  show (ManyApps _ xs) = show (symbolVal (Proxy :: Proxy s)) ++ " : " ++ show xs
+  show (OneApp _) = error "impossible"
+
+instance forall (s :: Symbol). GHCX.IsList (MultiApplication '[s]) where
+  type Item (MultiApplication '[s]) = Application
+
+  fromList [app] = OneApp app
+  fromList (_ : _ : _) = error "malformed (too long) MultiApplication OverloadedList!"
+  fromList [] = error "malformed (too short) MultiApplication OverloadedList!"
+
+  toList (OneApp app)   = [app]
+  toList (ManyApps _ _) = error "impossible"
+
+instance {-# OVERLAPPABLE #-} forall (s :: Symbol) (xs :: [Symbol])
+        . ( GHCX.IsList (MultiApplication xs)
+          , GHCX.Item (MultiApplication xs) ~ Application)
+       => GHCX.IsList (MultiApplication (s ': xs)) where
+  type Item (MultiApplication (s ': xs)) = Application
+
+  fromList (app : xs) = ManyApps app (GHCX.fromList xs :: MultiApplication xs)
+  fromList [] = error "malformed (too short) MultiApplication OverloadedList!"
+
+  toList (ManyApps app xs) = app : GHCX.toList xs
+  toList _                 = error "impossible"

--- a/test/WaiMultiSessionSpec.hs
+++ b/test/WaiMultiSessionSpec.hs
@@ -35,7 +35,7 @@ The API call graph for these tests looks like this
     |                  |
 /api/from_b        /api/from_a
     |                  |
-    -------> C <--------
+    -----> SumABC <-----
              |
          /api/sum/:c
              |
@@ -43,7 +43,7 @@ The API call graph for these tests looks like this
 
 The for_* APIs return the value of an IORef
 The from_* APIs return the value from the other service
-The sum API calls the two from_* APIs and adds their values with the provided :c
+The SumABC API calls the two from_* APIs and adds their values with the provided :c
 -}
 
 spec :: Spec

--- a/test/WaiMultiSessionSpec.hs
+++ b/test/WaiMultiSessionSpec.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedLists     #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RecursiveDo         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | These tests are examples of how to do integration tests between multiple
+-- distinct Wai-based applications in hspec-wai form (no need to spin up multiple
+-- concurrent servers on ports locally or test against a deployed environment)
+module WaiMultiSessionSpec where
+
+import           Test.Hspec
+import           Test.Hspec.Wai.Internal        (runWaiSession)
+import           Test.Hspec.Wai.Servant
+
+import           Test.Hspec.Wai.WaiMultiSession
+
+import           Control.Monad.IO.Class         (liftIO)
+import           Data.Functor.Identity          (Identity (..))
+import           Data.IORef
+import           Data.Proxy                     (Proxy (..))
+
+import           Network.Wai                    (Application)
+import           Servant.API
+import           Servant.Server                 (Server, serve)
+
+{-
+The API call graph for these tests looks like this
+(arrow direction is dataflow, so X -> Y means Y calls X)
+
+      -- /api/for_b ->
+    A <- /api/for_a -- B
+    |                  |
+/api/from_b        /api/from_a
+    |                  |
+    -------> C <--------
+             |
+         /api/sum/:c
+             |
+             v
+
+The for_* APIs return the value of an IORef
+The from_* APIs return the value from the other service
+The sum API calls the two from_* APIs and adds their values with the provided :c
+-}
+
+spec :: Spec
+spec = do
+  forA <- runIO $ newIORef 0
+  forB <- runIO $ newIORef 0
+
+  let multiProxy = Proxy :: Proxy '["a", "b", "sum"]
+  let sendA = sendWaiSession (Proxy :: Proxy "a") multiProxy
+  let sendB = sendWaiSession (Proxy :: Proxy "b") multiProxy
+  let sendSum = sendWaiSession (Proxy :: Proxy "sum") multiProxy
+
+  with (pure (wireUp forA forB)) $ do
+    describe "Test.Hspec.Wai.WaiMultiSession" $ do
+      it "should dispatch to the specified Application" $ do
+        liftIO $ writeIORef forA 1
+        liftIO $ writeIORef forB 2
+        (succeed $ sendB $ callForA) >>= liftIO . (`shouldBe` 1)
+        (succeed $ sendA $ callForB) >>= liftIO . (`shouldBe` 2)
+        (succeed $ sendSum $ callSumABC 3) >>= liftIO . (`shouldBe` 6)
+
+        sendB (callForB) `shouldRespondWith_` 404
+        sendA (callForA) `shouldRespondWith_` 404
+
+-- | @RecursiveDo@ + 'Identity' can be used to easily wire up cyclical 'Application'
+-- dependency graphs
+wireUp :: IORef Int -> IORef Int -> MultiApplication '["a", "b", "sum"]
+wireUp forA forB = runIdentity $ do
+  rec appA <- Identity $ mkAppA appB forB
+      appB <- Identity $ mkAppB appA forA
+  let appSum = mkAppSumABC appA appB
+  let (multiApp :: MultiApplication '["a", "b", "sum"]) = [appA, appB, appSum]
+  Identity multiApp
+
+type A = "api" :> "from_b" :> Get '[JSON] Int :<|> "api" :> "for_b" :> Get '[JSON] Int
+apiA :: Proxy A
+apiA = Proxy
+
+callFromB :: WaiSession (TestResponse Int)
+callForB :: WaiSession (TestResponse Int)
+(callFromB :<|> callForB) = client apiA
+
+serverA :: Application -> IORef Int -> Server A
+serverA app forB = liftIO (runWaiSession (succeed callForA) app) :<|> liftIO (readIORef forB)
+
+mkAppA :: Application -> IORef Int -> Application
+mkAppA app forB = serve apiA $ serverA app forB
+
+type B = "api" :> "from_a" :> Get '[JSON] Int :<|> "api" :> "for_a" :> Get '[JSON] Int
+apiB :: Proxy B
+apiB = Proxy
+
+callFromA :: WaiSession (TestResponse Int)
+callForA :: WaiSession (TestResponse Int)
+(callFromA :<|> callForA) = client apiB
+
+serverB :: Application -> IORef Int -> Server B
+serverB app forA = liftIO (runWaiSession (succeed callForB) app) :<|> liftIO (readIORef forA)
+
+mkAppB :: Application -> IORef Int -> Application
+mkAppB app forA = serve apiB $ serverB app forA
+
+type SumABC = "api" :> "sum" :> Capture "c" Int :> Get '[JSON] Int
+
+apiSumABC :: Proxy SumABC
+apiSumABC = Proxy
+
+callSumABC :: Int -> WaiSession (TestResponse Int)
+callSumABC = client apiSumABC
+
+serverSumABC :: Application -> Application -> Server SumABC
+serverSumABC appA appB = \c -> liftIO $ do
+  a <- runWaiSession (succeed callFromB) appA
+  b <- runWaiSession (succeed callFromA) appB
+  pure $ a + b + c
+
+mkAppSumABC :: Application -> Application -> Application
+mkAppSumABC appA appB = serve apiSumABC $ serverSumABC appA appB


### PR DESCRIPTION
Like `WaiSession` but with as many `Application`s as you want :)

Useful for integration tests between distinct services, but in the lightweight `hspec-wai` style.

### Summary
* Added `WaiMultiSession`, which is a `Reader` of a list of type-tagged `Application`s
* Refactored `Test.Hspec.Wai.Servant.Assertions` to work for `WaiSession` or `WaiMultiSession`
* Added a test that has 3 services that call each other in a non-trivial way to exercise `WaiMultiSession`. I'm happy with it!

### Testing Done
* `nix-build` succeeds w/tests passing
* I browsed the haddocks locally to make sure they seem useful