### PR TITLE
adapt to newer hspec-wai WaiSession type

### DIFF
--- a/hspec-wai-servant.cabal
+++ b/hspec-wai-servant.cabal
@@ -23,7 +23,7 @@ library
     Test.Hspec.Wai.Servant.Types
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <4.13
+      base >=4.9 && <5
     , hspec-wai
     , hspec-expectations
     , wai-extra
@@ -46,7 +46,7 @@ test-suite spec
       test
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <4.13
+      base >=4.9 && <5
     , aeson
     , hspec
     , servant

--- a/src/Test/Hspec/Wai/Servant/Assertions.hs
+++ b/src/Test/Hspec/Wai/Servant/Assertions.hs
@@ -25,9 +25,9 @@ import           Test.Hspec.Wai.Servant.Types
 -- 2) returns the response for later use
 shouldRespondWith
   :: HasCallStack
-  => W.WaiSession (TestResponse a)
+  => W.WaiSession st (TestResponse st a)
   -> W.ResponseMatcher
-  -> W.WaiSession (TestResponse a)
+  -> W.WaiSession st (TestResponse st a)
 shouldRespondWith action matcher = do
   tresp@(TestResponse _ _ sresp) <- action
   pure sresp `W.shouldRespondWith` matcher
@@ -36,14 +36,14 @@ shouldRespondWith action matcher = do
 -- | Like 'shouldRespondWith', but doesn't return the response
 shouldRespondWith_
   :: HasCallStack
-  => W.WaiSession (TestResponse a)
+  => W.WaiSession st (TestResponse st a)
   -> W.ResponseMatcher
-  -> W.WaiExpectation
+  -> W.WaiExpectation st
 shouldRespondWith_ = (void .) . shouldRespondWith
 
 -- | Checks if the provided @action@ returns 200. If so, attempts to decode
 -- the response.
-succeed :: HasCallStack => W.WaiSession (TestResponse a) -> W.WaiSession a
+succeed :: HasCallStack => W.WaiSession st (TestResponse st a) -> W.WaiSession st a
 succeed action = do
   tresp@(TestResponse _ req sres@(SResponse status _ _)) <- action
   if status == ok200
@@ -52,7 +52,7 @@ succeed action = do
 
 -- | Checks if the provided @action@ returns anything other than a 200. If so,
 -- sally forth.
-dontSucceed :: HasCallStack => W.WaiSession (TestResponse a) -> W.WaiSession ()
+dontSucceed :: HasCallStack => W.WaiSession st (TestResponse st a) -> W.WaiSession st ()
 dontSucceed action = do
   TestResponse _ req sres@(SResponse status _ _) <- action
   if status /= ok200

--- a/src/Test/Hspec/Wai/Servant/Types.hs
+++ b/src/Test/Hspec/Wai/Servant/Types.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString                 as B
 import qualified Data.ByteString.Char8           as BC
 import           Data.ByteString.Conversion.To   (toByteString')
 import qualified Data.ByteString.Lazy            as BL
-import           Data.Monoid                     ((<>))
 import           Data.Proxy                      (Proxy (..))
 import qualified Network.HTTP.Media.RenderHeader as HT
 import qualified Network.HTTP.Types              as HT
@@ -46,7 +45,7 @@ setReqBody :: (MimeRender ct a) => Proxy ct -> a -> TestRequest -> TestRequest
 setReqBody ctP a req = req { testBody = mimeRender ctP a, testHeaders = ("content-type", HT.renderHeader (contentType ctP)) : testHeaders req }
 
 -- | A raw SResponse along with a function to decode @a@
-data TestResponse a = TestResponse (SResponse -> WaiSession a) TestRequest SResponse
+data TestResponse st a = TestResponse (SResponse -> WaiSession st a) TestRequest SResponse
 
-getTestResponse :: TestResponse a -> WaiSession a
+getTestResponse :: TestResponse st a -> WaiSession st a
 getTestResponse (TestResponse k _ sresp) = k sresp

--- a/test/ClientSpec.hs
+++ b/test/ClientSpec.hs
@@ -95,17 +95,17 @@ server = pure
     :<|> throwError err500
     :<|> pure (BadValue True)
 
-idGet :: Int -> WaiSession (TestResponse Int)
-idPut :: Int -> WaiSession (TestResponse Int)
-idDelete :: Int -> WaiSession (TestResponse Int)
-idPost :: Int -> WaiSession (TestResponse Int)
-qparamMaybeToList :: Maybe Int -> WaiSession (TestResponse [Int])
-take' :: Int -> [Int] -> WaiSession (TestResponse [Int])
-reqbodyLength :: B.ByteString -> WaiSession (TestResponse Int)
-someHeaderLength :: Maybe T.Text -> WaiSession (TestResponse Int)
-_400s :: WaiSession (TestResponse ())
-_500s :: WaiSession (TestResponse ())
-decodingError :: WaiSession (TestResponse BadValue)
+idGet :: Int -> WaiSession () (TestResponse () Int)
+idPut :: Int -> WaiSession () (TestResponse () Int)
+idDelete :: Int -> WaiSession () (TestResponse () Int)
+idPost :: Int -> WaiSession () (TestResponse () Int)
+qparamMaybeToList :: Maybe Int -> WaiSession () (TestResponse () [Int])
+take' :: Int -> [Int] -> WaiSession () (TestResponse () [Int])
+reqbodyLength :: B.ByteString -> WaiSession () (TestResponse () Int)
+someHeaderLength :: Maybe T.Text -> WaiSession () (TestResponse () Int)
+_400s :: WaiSession () (TestResponse () ())
+_500s :: WaiSession () (TestResponse () ())
+decodingError :: WaiSession () (TestResponse () BadValue)
 
 (      idGet
   :<|> idPut


### PR DESCRIPTION
Not sure if this is useful or interesting in general, but I have "upgraded" types to use newer hspec-wai `WaiSession` type that takes a state as a parameter. 